### PR TITLE
refactor pipeline to make more intuitive

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,5 +2,5 @@
 .Rhistory
 .RData
 .Ruserdata
-
+*/out/*
 _targets/*

--- a/1_fetch/src/get_nwis_data.R
+++ b/1_fetch/src/get_nwis_data.R
@@ -1,13 +1,11 @@
-create_dirs <- function(site_num){
-  download_files_to <- file.path('1_fetch/out', paste0('nwis_', site_num, '_data.csv'))
-  return(download_files_to)
-}
 
-download_nwis_site_data <- function(site_num, download_files_to, parameterCd = '00010', startDate="2014-05-01", endDate="2015-05-01"){
+download_nwis_site_data <- function(site_num, download_files_to){
+  #create a directory to download the files to
+  download_files_to <- file.path('1_fetch/out', paste0('nwis_', site_num, '_data.csv'))
   
   # readNWISdata is from the dataRetrieval package
   data_out <- readNWISdata(sites=site_num, service="iv", 
-                           parameterCd = parameterCd, startDate = startDate, endDate = endDate)
+                           parameterCd = '00010', startDate="2014-05-01", endDate="2015-05-01")
   
   # -- simulating a failure-prone web-sevice here, do not edit --
   set.seed(Sys.time())
@@ -15,23 +13,22 @@ download_nwis_site_data <- function(site_num, download_files_to, parameterCd = '
     stop(site_num, ' has failed due to connection timeout. Try tar_make() again')
   }
   # -- end of do-not-edit block
-  correct_dir <- download_files_to[grep(site_num,download_files_to)]
-  write_csv(data_out, file = correct_dir)
-  return(correct_dir)
+  write_csv(data_out, file = download_files_to)
+  return(download_files_to)
 }
 
-concat_files_to_df <- function(){
-  downloaded_data <- list.files(path = '1_fetch/out', pattern = '_data.csv', full.names = T)
+concat_files_to_df <- function(csv_1, csv_2, csv_3, csv_4, csv_5){
+  downloaded_files <- c(csv_1, csv_2, csv_3, csv_4, csv_5)
   data_out <- data.frame()
-  for(downloaded_data in downloaded_data){
-    these_data <- read_csv(downloaded_data, col_types = 'ccTdcc')
+  for(df in downloaded_files){
+    these_data <- read_csv(df, col_types = 'ccTdcc')
     data_out <- bind_rows(data_out, these_data)
   }
   return(data_out)
 }
 
-nwis_site_info <- function(fileout, sites){
-  site_info <- dataRetrieval::readNWISsite(sites)
+nwis_site_info <- function(fileout){
+  site_info <- dataRetrieval::readNWISsite(siteNumbers=c("01427207", "01432160","01435000", "01436690", "01466500"))
   write_csv(site_info, file.path(fileout,'site_info.csv'))
   return(file.path(fileout,'site_info.csv'))
 }

--- a/1_fetch/src/get_nwis_data.R
+++ b/1_fetch/src/get_nwis_data.R
@@ -14,8 +14,8 @@ download_nwis_site_data <- function(site_num, download_files_to){
   return(download_files_to)
 }
 
-concat_files_to_df <- function(csv_1, csv_2, csv_3, csv_4, csv_5){
-  downloaded_files <- c(csv_1, csv_2, csv_3, csv_4, csv_5)
+concat_files_to_df <- function(downloaded_files){
+  #downloaded_files <- c(csv_1, csv_2, csv_3, csv_4, csv_5)
   data_out <- data.frame()
   for(df in downloaded_files){
     these_data <- read_csv(df, col_types = 'ccTdcc')

--- a/1_fetch/src/get_nwis_data.R
+++ b/1_fetch/src/get_nwis_data.R
@@ -1,48 +1,37 @@
-
-download_nwis_data <- function(site_nums = c("01427207", "01432160", "01435000", "01436690", "01466500")){
-  
-  # create the file names that are needed for download_nwis_site_data
-  # tempdir() creates a temporary directory that is wiped out when you start a new R session; 
-  # replace tempdir() with "1_fetch/out" or another desired folder if you want to retain the download
-  download_files <- file.path(tempdir(), paste0('nwis_', site_nums, '_data.csv'))
-  data_out <- data.frame()
-  # loop through files to download 
-  for (download_file in download_files){
-    download_nwis_site_data(download_file, parameterCd = '00010')
-    # read the downloaded data and append it to the existing data.frame
-    these_data <- read_csv(download_file, col_types = 'ccTdcc')
-    data_out <- bind_rows(data_out, these_data)
-  }
-  return(data_out)
+create_dirs <- function(site_num){
+  download_files_to <- file.path('1_fetch/out', paste0('nwis_', site_num, '_data.csv'))
+  return(download_files_to)
 }
 
-nwis_site_info <- function(fileout, site_data){
-  site_no <- unique(site_data$site_no)
-  site_info <- dataRetrieval::readNWISsite(site_no)
-  write_csv(site_info, fileout)
-  return(fileout)
-}
-
-
-download_nwis_site_data <- function(filepath, parameterCd = '00010', startDate="2014-05-01", endDate="2015-05-01"){
-  
-  # filepaths look something like directory/nwis_01432160_data.csv,
-  # remove the directory with basename() and extract the 01432160 with the regular expression match
-  site_num <- basename(filepath) %>% 
-    stringr::str_extract(pattern = "(?:[0-9]+)")
+download_nwis_site_data <- function(site_num, download_files_to, parameterCd = '00010', startDate="2014-05-01", endDate="2015-05-01"){
   
   # readNWISdata is from the dataRetrieval package
   data_out <- readNWISdata(sites=site_num, service="iv", 
                            parameterCd = parameterCd, startDate = startDate, endDate = endDate)
-
+  
   # -- simulating a failure-prone web-sevice here, do not edit --
   set.seed(Sys.time())
   if (sample(c(T,F,F,F), 1)){
     stop(site_num, ' has failed due to connection timeout. Try tar_make() again')
   }
   # -- end of do-not-edit block
-  
-  write_csv(data_out, file = filepath)
-  return(filepath)
+  correct_dir <- download_files_to[grep(site_num,download_files_to)]
+  write_csv(data_out, file = correct_dir)
+  return(correct_dir)
 }
 
+concat_files_to_df <- function(){
+  downloaded_data <- list.files(path = '1_fetch/out', pattern = '_data.csv', full.names = T)
+  data_out <- data.frame()
+  for(downloaded_data in downloaded_data){
+    these_data <- read_csv(downloaded_data, col_types = 'ccTdcc')
+    data_out <- bind_rows(data_out, these_data)
+  }
+  return(data_out)
+}
+
+nwis_site_info <- function(fileout, sites){
+  site_info <- dataRetrieval::readNWISsite(sites)
+  write_csv(site_info, file.path(fileout,'site_info.csv'))
+  return(file.path(fileout,'site_info.csv'))
+}

--- a/1_fetch/src/get_nwis_data.R
+++ b/1_fetch/src/get_nwis_data.R
@@ -1,8 +1,5 @@
 
 download_nwis_site_data <- function(site_num, download_files_to){
-  #create a directory to download the files to
-  download_files_to <- file.path('1_fetch/out', paste0('nwis_', site_num, '_data.csv'))
-  
   # readNWISdata is from the dataRetrieval package
   data_out <- readNWISdata(sites=site_num, service="iv", 
                            parameterCd = '00010', startDate="2014-05-01", endDate="2015-05-01")

--- a/_targets.R
+++ b/_targets.R
@@ -19,27 +19,27 @@ p1_targets_list <- list(
   # ),
   tar_target(
     nwis_01427207_data_csv,
-    download_nwis_site_data("01427207", create_directories),
+    download_nwis_site_data("01427207","nwis_01427207_data.csv"),
     format = "file"
   ),
   tar_target(
     nwis_01432160_data_csv,
-    download_nwis_site_data("01432160", create_directories),
+    download_nwis_site_data("01432160","nwis_01432160_data.csv"),
     format = "file"
   ),
   tar_target(
     nwis_01435000_data_csv,
-    download_nwis_site_data("01435000", create_directories),
+    download_nwis_site_data("01435000","nwis_01435000_data.csv"),
     format = "file"
   ),
   tar_target(
     nwis_01436690_data_csv,
-    download_nwis_site_data("01436690", create_directories),
+    download_nwis_site_data("01436690","nwis_01436690_data.csv"),
     format = "file"
   ),
   tar_target(
     nwis_01466500_data_csv,
-    download_nwis_site_data("01466500", create_directories),
+    download_nwis_site_data("01466500","nwis_01466500_data.csv"),
     format = "file"
   ),
   tar_target(

--- a/_targets.R
+++ b/_targets.R
@@ -5,19 +5,55 @@ source("3_visualize/src/plot_timeseries.R")
 
 options(tidyverse.quiet = TRUE)
 tar_option_set(packages = c("tidyverse", "dataRetrieval")) # Loading tidyverse because we need dplyr, ggplot2, readr, stringr, and purrr
-
+#site numbers
+sites = c("01427207", "01432160","01435000", "01436690", "01466500")
+#parameter codes for query
+parameterCd = '00010' 
+startDate="2014-05-01" 
+endDate="2015-05-01"
+#parameters for plotting
 p_width <- 12
 p_height <- 7
 p_units <- "in"
 
 p1_targets_list <- list(
   tar_target(
-    site_data,
-    download_nwis_data(),
+    create_directories,
+    create_dirs(sites),
+    format = "file"
+  ),
+  tar_target(
+    site_data_1,
+    download_nwis_site_data(sites[1], create_directories,parameterCd, startDate, endDate),
+    format = "file"
+  ),
+  tar_target(
+    site_data_2,
+    download_nwis_site_data(sites[2], create_directories,parameterCd, startDate=, endDate=),
+    format = "file"
+  ),
+  tar_target(
+    site_data_3,
+    download_nwis_site_data(sites[3], create_directories,parameterCd, startDate=, endDate=),
+    format = "file"
+  ),
+  tar_target(
+    site_data_4,
+    download_nwis_site_data(sites[4], create_directories,parameterCd, startDate=, endDate=),
+    format = "file"
+  ),
+  tar_target(
+    site_data_5,
+    download_nwis_site_data(sites[5], create_directories,parameterCd, startDate=, endDate=),
+    format = "file"
+  ),
+  tar_target(
+    site_data_concat,
+    concat_files_to_df()
   ),
   tar_target(
     site_info_csv,
-    nwis_site_info(fileout = "1_fetch/out/site_info.csv", site_data),
+    nwis_site_info(fileout = '1_fetch/out', sites = sites),
     format = "file"
   )
 )
@@ -25,7 +61,7 @@ p1_targets_list <- list(
 p2_targets_list <- list(
   tar_target(
     site_data_clean, 
-    process_data(site_data)
+    process_data(site_data_concat)
   ),
   tar_target(
     site_data_annotated,

--- a/_targets.R
+++ b/_targets.R
@@ -44,7 +44,7 @@ p1_targets_list <- list(
   ),
   tar_target(
     site_data_concat,
-    concat_files_to_df(nwis_01427207_data_csv, nwis_01432160_data_csv, nwis_01435000_data_csv, nwis_01436690_data_csv, nwis_01466500_data_csv)
+    concat_files_to_df(c(nwis_01427207_data_csv, nwis_01432160_data_csv, nwis_01435000_data_csv, nwis_01436690_data_csv, nwis_01466500_data_csv))
   ),
   tar_target(
     site_info_csv,

--- a/_targets.R
+++ b/_targets.R
@@ -6,54 +6,49 @@ source("3_visualize/src/plot_timeseries.R")
 options(tidyverse.quiet = TRUE)
 tar_option_set(packages = c("tidyverse", "dataRetrieval")) # Loading tidyverse because we need dplyr, ggplot2, readr, stringr, and purrr
 #site numbers
-sites = c("01427207", "01432160","01435000", "01436690", "01466500")
+#sites = c("01427207", "01432160","01435000", "01436690", "01466500")
 #parameter codes for query
-parameterCd = '00010' 
-startDate="2014-05-01" 
-endDate="2015-05-01"
-#parameters for plotting
-p_width <- 12
-p_height <- 7
-p_units <- "in"
+
+
 
 p1_targets_list <- list(
+  # tar_target(
+  #   create_directories,
+  #   create_dirs(site_num = c("01427207", "01432160","01435000", "01436690", "01466500")),
+  #   format = "file"
+  # ),
   tar_target(
-    create_directories,
-    create_dirs(sites),
+    nwis_01427207_data_csv,
+    download_nwis_site_data("01427207", create_directories),
     format = "file"
   ),
   tar_target(
-    site_data_1,
-    download_nwis_site_data(sites[1], create_directories,parameterCd, startDate, endDate),
+    nwis_01432160_data_csv,
+    download_nwis_site_data("01432160", create_directories),
     format = "file"
   ),
   tar_target(
-    site_data_2,
-    download_nwis_site_data(sites[2], create_directories,parameterCd, startDate=, endDate=),
+    nwis_01435000_data_csv,
+    download_nwis_site_data("01435000", create_directories),
     format = "file"
   ),
   tar_target(
-    site_data_3,
-    download_nwis_site_data(sites[3], create_directories,parameterCd, startDate=, endDate=),
+    nwis_01436690_data_csv,
+    download_nwis_site_data("01436690", create_directories),
     format = "file"
   ),
   tar_target(
-    site_data_4,
-    download_nwis_site_data(sites[4], create_directories,parameterCd, startDate=, endDate=),
-    format = "file"
-  ),
-  tar_target(
-    site_data_5,
-    download_nwis_site_data(sites[5], create_directories,parameterCd, startDate=, endDate=),
+    nwis_01466500_data_csv,
+    download_nwis_site_data("01466500", create_directories),
     format = "file"
   ),
   tar_target(
     site_data_concat,
-    concat_files_to_df()
+    concat_files_to_df(nwis_01427207_data_csv, nwis_01432160_data_csv, nwis_01435000_data_csv, nwis_01436690_data_csv, nwis_01466500_data_csv)
   ),
   tar_target(
     site_info_csv,
-    nwis_site_info(fileout = '1_fetch/out', sites = sites),
+    nwis_site_info(fileout = '1_fetch/out'),
     format = "file"
   )
 )
@@ -77,7 +72,7 @@ p3_targets_list <- list(
   tar_target(
     figure_1_png,
     plot_nwis_timeseries(fileout = "3_visualize/out/figure_1.png", site_data_styled,
-                         width = p_width, height = p_height, units = p_units),
+                         width = 12, height = 7, units = "in"),
     format = "file"
   )
 )


### PR DESCRIPTION
I tried to improve this pipeline by creating a target for each individual site. I also broke the ```site_data``` target into 4 separate targets: 1) ```create_directories``` creates directories where each site's data will be downloaded, 2) ```site_data_n``` downloads each site's data and writes it to the directory (one target for each site), 3) ```site_concat_data``` reads the downloaded data and concatenates the data into a single data frame, finally 4) ```site_info_csv``` queries the site info for the site and writes it to a csv.