### PR TITLE
swap 2 files for objects and 1 object for file

### DIFF
--- a/1_fetch/src/get_nwis_data.R
+++ b/1_fetch/src/get_nwis_data.R
@@ -31,15 +31,15 @@ download_nwis_site_data_object <- function(site_num){
   return(data_out)
 }
 
-concat_files_to_df <- function(target_files, target_object_1, target_object_2){
+concat_files_to_df <- function(target_object_1, target_object_2, target_object_3, target_object_4, target_object_5){
 
-  data_out_files <- data.frame()
-  for(df_files in target_files){
-    these_data <- read_csv(df_files, col_types = 'ccTdcc')
-    data_out_files <- bind_rows(data_out_files, these_data)
-  }
+  # data_out_files <- data.frame()
+  # for(df_files in target_files){
+  #   these_data <- read_csv(df_files, col_types = 'ccTdcc')
+  #   data_out_files <- bind_rows(data_out_files, these_data)
+  # }
   
-  data_out <- bind_rows(data_out_files, target_object_1, target_object_2)
+  data_out <- bind_rows(target_object_1, target_object_2, target_object_3, target_object_4, target_object_5)
   return(data_out)
 }
 

--- a/1_fetch/src/get_nwis_data.R
+++ b/1_fetch/src/get_nwis_data.R
@@ -1,5 +1,6 @@
 
-download_nwis_site_data <- function(site_num, download_files_to){
+#function for downloading data to targets file
+download_nwis_site_data_file <- function(site_num, download_files_to){
   # readNWISdata is from the dataRetrieval package
   data_out <- readNWISdata(sites=site_num, service="iv", 
                            parameterCd = '00010', startDate="2014-05-01", endDate="2015-05-01")
@@ -14,13 +15,31 @@ download_nwis_site_data <- function(site_num, download_files_to){
   return(download_files_to)
 }
 
-concat_files_to_df <- function(downloaded_files){
-  #downloaded_files <- c(csv_1, csv_2, csv_3, csv_4, csv_5)
-  data_out <- data.frame()
-  for(df in downloaded_files){
-    these_data <- read_csv(df, col_types = 'ccTdcc')
-    data_out <- bind_rows(data_out, these_data)
+#function for downloading data to targets object 
+download_nwis_site_data_object <- function(site_num){
+  # readNWISdata is from the dataRetrieval package
+  data_out <- readNWISdata(sites=site_num, service="iv", 
+                           parameterCd = '00010', startDate="2014-05-01", endDate="2015-05-01")
+  
+  # -- simulating a failure-prone web-sevice here, do not edit --
+  set.seed(Sys.time())
+  if (sample(c(T,F,F,F), 1)){
+    stop(site_num, ' has failed due to connection timeout. Try tar_make() again')
   }
+  # -- end of do-not-edit block
+  #write_csv(data_out, file = download_files_to)
+  return(data_out)
+}
+
+concat_files_to_df <- function(target_files, target_object_1, target_object_2){
+
+  data_out_files <- data.frame()
+  for(df_files in target_files){
+    these_data <- read_csv(df_files, col_types = 'ccTdcc')
+    data_out_files <- bind_rows(data_out_files, these_data)
+  }
+  
+  data_out <- bind_rows(data_out_files, target_object_1, target_object_2)
   return(data_out)
 }
 

--- a/2_process/src/process_and_style.R
+++ b/2_process/src/process_and_style.R
@@ -1,20 +1,19 @@
-process_data <- function(nwis_data, clean_data_to){
+process_data <- function(nwis_data){
   nwis_data_clean <- rename(nwis_data, water_temperature = X_00010_00000) %>% 
     select(-agency_cd, -X_00010_00000_cd, -tz_cd)
   
   return(nwis_data_clean)
 }
 
-annotate_data <- function(site_data_clean, site_filename, save_annotated_data_csv){
+annotate_data <- function(site_data_clean, site_filename){
   site_info <- read_csv(site_filename)
   annotated_data <- left_join(site_data_clean, site_info, by = "site_no") %>% 
     select(station_name = station_nm, site_no, dateTime, water_temperature, latitude = dec_lat_va, longitude = dec_long_va)
-  write.csv(annotated_data, save_annotated_data_csv)
-  return(save_annotated_data_csv)
+  
+  return(annotated_data)
 }
 
 
-style_data <- function(site_data_annotated_csv){
-  site_data_annotated <- read_csv(site_data_annotated_csv)
+style_data <- function(site_data_annotated){
   mutate(site_data_annotated, station_name = as.factor(station_name))
 }

--- a/2_process/src/process_and_style.R
+++ b/2_process/src/process_and_style.R
@@ -1,19 +1,20 @@
-process_data <- function(nwis_data){
+process_data <- function(nwis_data, clean_data_to){
   nwis_data_clean <- rename(nwis_data, water_temperature = X_00010_00000) %>% 
     select(-agency_cd, -X_00010_00000_cd, -tz_cd)
   
   return(nwis_data_clean)
 }
 
-annotate_data <- function(site_data_clean, site_filename){
+annotate_data <- function(site_data_clean, site_filename, save_annotated_data_csv){
   site_info <- read_csv(site_filename)
   annotated_data <- left_join(site_data_clean, site_info, by = "site_no") %>% 
     select(station_name = station_nm, site_no, dateTime, water_temperature, latitude = dec_lat_va, longitude = dec_long_va)
-  
-  return(annotated_data)
+  write.csv(annotated_data, save_annotated_data_csv)
+  return(save_annotated_data_csv)
 }
 
 
-style_data <- function(site_data_annotated){
+style_data <- function(site_data_annotated_csv){
+  site_data_annotated <- read_csv(site_data_annotated_csv)
   mutate(site_data_annotated, station_name = as.factor(station_name))
 }

--- a/_targets.R
+++ b/_targets.R
@@ -13,19 +13,16 @@ tar_option_set(packages = c("tidyverse", "dataRetrieval")) # Loading tidyverse b
 
 p1_targets_list <- list(
   tar_target(
-    nwis_01427207_data_csv,
-    download_nwis_site_data_file("01427207","nwis_01427207_data.csv"),
-    format = "file"
+    nwis_01427207_data,
+    download_nwis_site_data_object("01427207")
   ),
   tar_target(
-    nwis_01432160_data_csv,
-    download_nwis_site_data_file("01432160","nwis_01432160_data.csv"),
-    format = "file"
+    nwis_01432160_data,
+    download_nwis_site_data_object("01432160")
   ),
   tar_target(
-    nwis_01435000_data_csv,
-    download_nwis_site_data_file("01435000","nwis_01435000_data.csv"),
-    format = "file"
+    nwis_01435000_data,
+    download_nwis_site_data_object("01435000")
   ),
   tar_target(
     nwis_01436690_data,
@@ -37,7 +34,7 @@ p1_targets_list <- list(
   ),
   tar_target(
     site_data_concat,
-    concat_files_to_df(target_files = c(nwis_01427207_data_csv, nwis_01432160_data_csv, nwis_01435000_data_csv), target_object_1 = nwis_01436690_data, target_object_2 = nwis_01466500_data)
+    concat_files_to_df(target_object_1 = nwis_01427207_data, target_object_2 = nwis_01432160_data, target_object_3 = nwis_01435000_data, target_object_4 = nwis_01436690_data, target_object_5 = nwis_01466500_data)
   ),
   tar_target(
     site_info_csv,
@@ -52,13 +49,12 @@ p2_targets_list <- list(
     process_data(site_data_concat)
   ),
   tar_target(
-    site_data_annotated_csv,
-    annotate_data(site_data_clean, site_filename = site_info_csv, save_annotated_data_csv = '2_process/out/site_data_annotated.csv'),
-    format = 'file'
+    site_data_annotated,
+    annotate_data(site_data_clean, site_filename = site_info_csv)
   ),
   tar_target(
     site_data_styled,
-    style_data(site_data_annotated_csv)
+    style_data(site_data_annotated)
   )
 )
 

--- a/_targets.R
+++ b/_targets.R
@@ -12,39 +12,32 @@ tar_option_set(packages = c("tidyverse", "dataRetrieval")) # Loading tidyverse b
 
 
 p1_targets_list <- list(
-  # tar_target(
-  #   create_directories,
-  #   create_dirs(site_num = c("01427207", "01432160","01435000", "01436690", "01466500")),
-  #   format = "file"
-  # ),
   tar_target(
     nwis_01427207_data_csv,
-    download_nwis_site_data("01427207","nwis_01427207_data.csv"),
+    download_nwis_site_data_file("01427207","nwis_01427207_data.csv"),
     format = "file"
   ),
   tar_target(
     nwis_01432160_data_csv,
-    download_nwis_site_data("01432160","nwis_01432160_data.csv"),
+    download_nwis_site_data_file("01432160","nwis_01432160_data.csv"),
     format = "file"
   ),
   tar_target(
     nwis_01435000_data_csv,
-    download_nwis_site_data("01435000","nwis_01435000_data.csv"),
+    download_nwis_site_data_file("01435000","nwis_01435000_data.csv"),
     format = "file"
   ),
   tar_target(
-    nwis_01436690_data_csv,
-    download_nwis_site_data("01436690","nwis_01436690_data.csv"),
-    format = "file"
+    nwis_01436690_data,
+    download_nwis_site_data_object("01436690")
   ),
   tar_target(
-    nwis_01466500_data_csv,
-    download_nwis_site_data("01466500","nwis_01466500_data.csv"),
-    format = "file"
+    nwis_01466500_data,
+    download_nwis_site_data_object("01466500")
   ),
   tar_target(
     site_data_concat,
-    concat_files_to_df(c(nwis_01427207_data_csv, nwis_01432160_data_csv, nwis_01435000_data_csv, nwis_01436690_data_csv, nwis_01466500_data_csv))
+    concat_files_to_df(target_files = c(nwis_01427207_data_csv, nwis_01432160_data_csv, nwis_01435000_data_csv), target_object_1 = nwis_01436690_data, target_object_2 = nwis_01466500_data)
   ),
   tar_target(
     site_info_csv,
@@ -59,12 +52,13 @@ p2_targets_list <- list(
     process_data(site_data_concat)
   ),
   tar_target(
-    site_data_annotated,
-    annotate_data(site_data_clean, site_filename = site_info_csv)
+    site_data_annotated_csv,
+    annotate_data(site_data_clean, site_filename = site_info_csv, save_annotated_data_csv = '2_process/out/site_data_annotated.csv'),
+    format = 'file'
   ),
   tar_target(
     site_data_styled,
-    style_data(site_data_annotated)
+    style_data(site_data_annotated_csv)
   )
 )
 


### PR DESCRIPTION
Hi Scott. For issue #8 I converted the last two site targets to output objects instead of files, and I converted the ```site_data_annotated``` target into ```site_data_annotated_csv``` with ```format='file'``` to write to a csv